### PR TITLE
Issue28: Fixing language bug

### DIFF
--- a/packages/app/src/utils/locale.js
+++ b/packages/app/src/utils/locale.js
@@ -7,8 +7,16 @@ export const getUserLocale = () => {
     navigator.language ||
     navigator.userLanguage;
 
-  // Returns "en"
-  return languageCode.split('-')[0];
+  // language-code = primary-code ( "-" subcode )*
+  // Subcode is usually the Country Code
+  const langPrimaryCode = languageCode.split('-')[0];
+
+  const defaultEnLanguageFallback =
+    langPrimaryCode !== 'da' || langPrimaryCode !== 'en'
+      ? 'en'
+      : langPrimaryCode;
+
+  return defaultEnLanguageFallback;
 };
 
 export async function activate(locale) {


### PR DESCRIPTION
A language code consists of a primary-code and a subcode. F.ex., en-GB.

My solution checks for the primary-code, and if it's not English or Danish, it returns 'en'.

Now it works with the Greek browser.

close #28 