### PR TITLE
bug fix #40 parser upgraded to work with react router v6

### DIFF
--- a/packages/parser/src/ASTParser.ts
+++ b/packages/parser/src/ASTParser.ts
@@ -184,6 +184,15 @@ class ASTParser {
               ASTParser.logEntry(`[Info] Open jsxElement`);
               jsxElement.open(node);
             } else {
+              if (node.name.type === 'JSXIdentifier') {
+                if (
+                  jsxElement.isRoute() &&
+                  attribute.getElementName() == 'element'
+                ) {
+                  jsxElement.isRouteElement = true;
+                  jsxElement.setName(node.name.name);
+                }
+              }
               if (
                 jsxElement.isRoute() &&
                 attribute.getElementName() == 'render'


### PR DESCRIPTION
added some code with recognises the components rendered by the syntax of react-router v6