### PR TITLE
Implementing collapsible sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "eslint-plugin-simple-import-sort": "^7.0.0",
     "lerna": "^3.22.1",
     "prettier": "^2.2.1",
     "typescript": "^4.1.5"

--- a/packages/bratus-app/.eslintrc.js
+++ b/packages/bratus-app/.eslintrc.js
@@ -21,7 +21,7 @@ module.exports = {
       version: 'detect',
     },
   },
-  plugins: ['react', 'react-hooks', 'prettier', 'simple-import-sort'],
+  plugins: ['react', 'react-hooks', 'prettier'],
   rules: {
     'prettier/prettier': [
       'error',
@@ -29,8 +29,6 @@ module.exports = {
       { usePrettierrc: true },
     ],
     'react/display-name': 'off',
-    'simple-import-sort/imports': 'error',
-    'simple-import-sort/exports': 'error',
     'react/prop-types': ['error', { ignore: ['children'] }],
   },
 };

--- a/packages/bratus-app/package.json
+++ b/packages/bratus-app/package.json
@@ -59,7 +59,6 @@
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "eslint-plugin-simple-import-sort": "^7.0.0",
     "prettier": "^2.2.1"
   },
   "gitHead": "6de840ebd664b9cae7defc39031816cb106a62ad"

--- a/packages/bratus-app/src/components/ComponentTree/ComponentTree.jsx
+++ b/packages/bratus-app/src/components/ComponentTree/ComponentTree.jsx
@@ -1,11 +1,12 @@
 // import ColorHash from 'color-hash';
 import PropTypes from 'prop-types';
 import React, { useContext } from 'react';
-import ReactFlow, { Controls as ZoomControlButtons } from 'react-flow-renderer';
+import ReactFlow from 'react-flow-renderer';
 
 // import StyledMiniMap from '../Minimap/Minimap.sc';
 import HighlightedComponentsContext from '../../contexts/HighlightedComponentsContext';
 import ComponentNode from '../ComponentNode/ComponentNode';
+import { ZoomControlButtons } from './ComponentTree.sc';
 
 const ComponentTree = ({ elements }) => {
   const { highlightedComponents, setHighlightedComponents } = useContext(

--- a/packages/bratus-app/src/components/ComponentTree/ComponentTree.sc.js
+++ b/packages/bratus-app/src/components/ComponentTree/ComponentTree.sc.js
@@ -1,0 +1,7 @@
+import { Controls } from 'react-flow-renderer';
+
+import styled from 'styled-components';
+
+export const ZoomControlButtons = styled(Controls)`
+  bottom: 70px;
+`;

--- a/packages/bratus-app/src/components/DefaultLayoutPage/DefaultLayout.jsx
+++ b/packages/bratus-app/src/components/DefaultLayoutPage/DefaultLayout.jsx
@@ -1,14 +1,16 @@
-import { QuestionCircleOutlined } from '@ant-design/icons';
+import { LeftCircleOutlined } from '@ant-design/icons';
 import { Drawer as ComponentDetailsDrawer, Layout } from 'antd';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import { ReactFlowProvider } from 'react-flow-renderer';
-
 import useStickyState from '../../hooks/useStickyState';
 import ComponentDetails from '../ComponentDetails/ComponentDetails';
 import HelpPanel from '../HelpPanel/HelpPanel';
-import Navigation from '../NavigationPanel/NavigationPanel';
-import { HelpPanelButton, MainContentWrapper } from './DefaultLayout.sc';
+import NavigationPanel from '../NavigationPanel/NavigationPanel';
+import {
+  MainContentWrapper,
+  NavigationTriggerButton,
+} from './DefaultLayout.sc';
 
 const DefaultLayout = ({ children, info, nodeDetail, setNodeDetail }) => {
   const [hideHelpOnStartUp, setHideHelpOnStartUp] = useStickyState(
@@ -20,12 +22,34 @@ const DefaultLayout = ({ children, info, nodeDetail, setNodeDetail }) => {
     !hideHelpOnStartUp ? true : false
   );
 
+  const [collapsed, setCollapsed] = useState(false);
+
   return (
     <Layout>
       <ReactFlowProvider>
-        <Navigation info={info} />
+        <NavigationPanel
+          setIsHelpVisible={setIsHelpVisible}
+          setCollapsed={setCollapsed}
+          collapsed={collapsed}
+          info={info}
+        />
 
-        <MainContentWrapper>{children}</MainContentWrapper>
+        <NavigationTriggerButton
+          collapsed={collapsed}
+          icon={<LeftCircleOutlined rotate={collapsed && 180} />}
+          type="primary"
+          shape="round"
+          size="large"
+          onClick={() => {
+            setCollapsed(!collapsed);
+          }}
+        >
+          {collapsed ? <span>Show Nav</span> : <span>Hide Nav</span>}
+        </NavigationTriggerButton>
+
+        <MainContentWrapper collapsed={collapsed}>
+          {children}
+        </MainContentWrapper>
 
         <ComponentDetailsDrawer
           width={800}
@@ -47,16 +71,6 @@ const DefaultLayout = ({ children, info, nodeDetail, setNodeDetail }) => {
           setHideHelpOnStartUp={setHideHelpOnStartUp}
         />
       </ReactFlowProvider>
-
-      <HelpPanelButton
-        type="primary"
-        shape={'round'}
-        size="large"
-        icon={<QuestionCircleOutlined />}
-        onClick={() => setIsHelpVisible(true)}
-      >
-        Open help
-      </HelpPanelButton>
     </Layout>
   );
 };

--- a/packages/bratus-app/src/components/DefaultLayoutPage/DefaultLayout.sc.js
+++ b/packages/bratus-app/src/components/DefaultLayoutPage/DefaultLayout.sc.js
@@ -4,13 +4,18 @@ import styled from 'styled-components';
 import { baseUnit, navigationWidth } from '../../utils/tokens/units';
 
 export const MainContentWrapper = styled(Layout)`
-  margin-left: ${navigationWidth}px;
+  margin-left: ${({ collapsed }) =>
+    collapsed === false ? `${navigationWidth}px` : '0'};
   padding: 1rem;
   height: 100vh;
 `;
 
-export const HelpPanelButton = styled(Button)`
+export const NavigationTriggerButton = styled(Button)`
   position: absolute;
   bottom: ${baseUnit * 2}px;
-  left: ${baseUnit * 2}px;
+  left: ${({ collapsed }) =>
+    collapsed === true
+      ? `${baseUnit * 2}px`
+      : `${navigationWidth + baseUnit * 2}px`};
+  z-index: 999;
 `;

--- a/packages/bratus-app/src/components/NavigationPanel/NavigationPanel.jsx
+++ b/packages/bratus-app/src/components/NavigationPanel/NavigationPanel.jsx
@@ -88,79 +88,96 @@ const Navigation = () => {
       );
     }
   };
+
+  const [collapsed, setCollapsed] = useState(true);
+
   return (
-    <NavigationSider width={navigationWidth}>
-      <AppTitle level={1}>React-bratus</AppTitle>
+    <>
+      <NavigationSider
+        collapsed={collapsed}
+        collapsedWidth={0}
+        trigger={null}
+        width={navigationWidth}
+      >
+        <AppTitle level={1}>React-bratus</AppTitle>
 
-      <Menu theme="dark" mode="inline">
-        <NavigationSection title="Search">
-          <TreeComponentDropdown
-            showSearch
-            value={searchField}
-            dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
-            placeholder="Search components"
-            onChange={onChange}
-            treeDataSimpleMode
-            treeDefaultExpandAll={false}
-            treeData={searchOptions}
-          />
-        </NavigationSection>
+        <Menu theme="dark" mode="inline">
+          <NavigationSection title="Search">
+            <TreeComponentDropdown
+              showSearch
+              value={searchField}
+              dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+              placeholder="Search components"
+              onChange={onChange}
+              treeDataSimpleMode
+              treeDefaultExpandAll={false}
+              treeData={searchOptions}
+            />
+          </NavigationSection>
 
-        <NavigationSection title="Actions">
-          <NavigationActionButtons />
-        </NavigationSection>
+          <NavigationSection title="Actions">
+            <NavigationActionButtons />
+          </NavigationSection>
 
-        <NavigationSection title="Component Background">
-          <ColorInfoParagraph>
-            Determine how to colour the components.
-          </ColorInfoParagraph>
+          <NavigationSection title="Component Background">
+            <ColorInfoParagraph>
+              Determine how to colour the components.
+            </ColorInfoParagraph>
 
-          <DropdownInput
-            defaultValue={
-              !componentBackground.mode ? 'white' : componentBackground.mode
-            }
-            onChange={(value) =>
-              setComponentBackground({ ...componentBackground, mode: value })
-            }
-          >
-            <Select.Option value="white">White</Select.Option>
+            <DropdownInput
+              defaultValue={
+                !componentBackground.mode ? 'white' : componentBackground.mode
+              }
+              onChange={(value) =>
+                setComponentBackground({ ...componentBackground, mode: value })
+              }
+            >
+              <Select.Option value="white">White</Select.Option>
 
-            <Select.Option value="label_hash">
-              Based on Label Hash
-            </Select.Option>
+              <Select.Option value="label_hash">
+                Based on Label Hash
+              </Select.Option>
 
-            <Select.Option value="loc_reference">
-              Based on Lines of Code
-            </Select.Option>
-          </DropdownInput>
+              <Select.Option value="loc_reference">
+                Based on Lines of Code
+              </Select.Option>
+            </DropdownInput>
 
-          {componentBackground.mode === 'loc_reference' && (
-            <BaselineInputWrapper>
-              <Input
-                addonBefore={'Baseline'}
-                placeholder={'LOC Reference'}
-                defaultValue={componentBackground.locReference}
-                onChange={(e) => {
-                  if (e.target.value < 1) {
-                    setComponentBackground({
-                      ...componentBackground,
-                      locReference: 1,
-                    });
-                  } else {
-                    setComponentBackground({
-                      ...componentBackground,
-                      locReference: e.target.value,
-                    });
-                  }
-                }}
-                type="number"
-                min="1"
-              />
-            </BaselineInputWrapper>
-          )}
-        </NavigationSection>
-      </Menu>
-    </NavigationSider>
+            {componentBackground.mode === 'loc_reference' && (
+              <BaselineInputWrapper>
+                <Input
+                  addonBefore={'Baseline'}
+                  placeholder={'LOC Reference'}
+                  defaultValue={componentBackground.locReference}
+                  onChange={(e) => {
+                    if (e.target.value < 1) {
+                      setComponentBackground({
+                        ...componentBackground,
+                        locReference: 1,
+                      });
+                    } else {
+                      setComponentBackground({
+                        ...componentBackground,
+                        locReference: e.target.value,
+                      });
+                    }
+                  }}
+                  type="number"
+                  min="1"
+                />
+              </BaselineInputWrapper>
+            )}
+          </NavigationSection>
+        </Menu>
+      </NavigationSider>
+      <button
+        onClick={() => {
+          setCollapsed(!collapsed);
+        }}
+      >
+        Hello Im a button
+      </button>
+    </>
   );
 };
 

--- a/packages/bratus-app/src/components/NavigationPanel/NavigationPanel.jsx
+++ b/packages/bratus-app/src/components/NavigationPanel/NavigationPanel.jsx
@@ -10,13 +10,17 @@ import {
   BaselineInputWrapper,
   ColorInfoParagraph,
   DropdownInput,
+  HelpPanelButton,
   NavigationSider,
   TreeComponentDropdown,
 } from './NavigationPanel.sc';
+import PropTypes from 'prop-types';
+
 import NavigationActionButtons from './private/NavigationActionButtons/NavigationActionButtons';
 import NavigationSection from './private/NavigationSection/NavigationSection';
+import { QuestionCircleOutlined } from '@ant-design/icons';
 
-const Navigation = () => {
+const NavigationPanel = ({ collapsed, setIsHelpVisible }) => {
   const [searchField, setSearchField] = useState();
   const [searchOptions, setSearchOptions] = useState([]);
   const { highlightedComponents, setHighlightedComponents } = useContext(
@@ -89,14 +93,11 @@ const Navigation = () => {
     }
   };
 
-  const [collapsed, setCollapsed] = useState(true);
-
   return (
     <>
       <NavigationSider
         collapsed={collapsed}
         collapsedWidth={0}
-        trigger={null}
         width={navigationWidth}
       >
         <AppTitle level={1}>React-bratus</AppTitle>
@@ -167,18 +168,26 @@ const Navigation = () => {
                 />
               </BaselineInputWrapper>
             )}
+
+            <HelpPanelButton
+              type="primary"
+              shape={'round'}
+              size="large"
+              icon={<QuestionCircleOutlined />}
+              onClick={() => setIsHelpVisible(true)}
+            >
+              Open help
+            </HelpPanelButton>
           </NavigationSection>
         </Menu>
       </NavigationSider>
-      <button
-        onClick={() => {
-          setCollapsed(!collapsed);
-        }}
-      >
-        Hello Im a button
-      </button>
     </>
   );
 };
 
-export default Navigation;
+NavigationPanel.propTypes = {
+  collapsed: PropTypes.any,
+  setIsHelpVisible: PropTypes.any,
+};
+
+export default NavigationPanel;

--- a/packages/bratus-app/src/components/NavigationPanel/NavigationPanel.sc.js
+++ b/packages/bratus-app/src/components/NavigationPanel/NavigationPanel.sc.js
@@ -1,4 +1,4 @@
-import { Select, TreeSelect } from 'antd';
+import { Select, TreeSelect, Button } from 'antd';
 import Sider from 'antd/lib/layout/Sider';
 import Paragraph from 'antd/lib/typography/Paragraph';
 import Title from 'antd/lib/typography/Title';
@@ -40,4 +40,10 @@ export const BaselineInputWrapper = styled.div`
 export const TreeComponentDropdown = styled(TreeSelect)`
   width: 100%;
   padding: 0 ${baseUnit}px;
+`;
+
+export const HelpPanelButton = styled(Button)`
+  position: absolute;
+  bottom: ${baseUnit * 2}px;
+  left: ${baseUnit * 2}px;
 `;

--- a/packages/bratus-app/src/react-app-env.d.ts
+++ b/packages/bratus-app/src/react-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react-scripts" />

--- a/packages/bratus-app/src/utils/functions/graphUtils.js
+++ b/packages/bratus-app/src/utils/functions/graphUtils.js
@@ -20,7 +20,6 @@ export const getLayoutedElements = (elements, direction = 'LR') => {
   dagreGraph.setGraph({ rankdir: direction });
   const aditionalSpaceMultiplier = 2;
 
-  console.log('elements', elements);
   elements.forEach((el) => {
     if (isNode(el)) {
       dagreGraph.setNode(el.id, {
@@ -37,7 +36,6 @@ export const getLayoutedElements = (elements, direction = 'LR') => {
   return elements.map((el) => {
     if (isNode(el)) {
       const nodeWithPosition = dagreGraph.node(el.id);
-      console.log(isHorizontal);
       el.targetPosition = isHorizontal ? 'left' : 'top';
       el.sourcePosition = isHorizontal ? 'right' : 'bottom';
 

--- a/packages/bratus-app/tsconfig.json
+++ b/packages/bratus-app/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/bratus-cli/.eslintrc.js
+++ b/packages/bratus-cli/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
     es6: true,
   },
   parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint', 'prettier', 'simple-import-sort'],
+  plugins: ['@typescript-eslint', 'prettier'],
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/eslint-recommended',
@@ -18,8 +18,6 @@ module.exports = {
       { endOfLine: 'auto' },
       { usePrettierrc: true },
     ],
-    'simple-import-sort/imports': 'error',
-    'simple-import-sort/exports': 'error',
     '@typescript-eslint/no-var-requires': 'off',
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6720,11 +6720,6 @@ eslint-plugin-react@^7.21.5, eslint-plugin-react@^7.22.0:
     resolve "^2.0.0-next.3"
     string.prototype.matchall "^4.0.4"
 
-eslint-plugin-simple-import-sort@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz#a1dad262f46d2184a90095a60c66fef74727f0f8"
-  integrity sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==
-
 eslint-plugin-testing-library@^3.9.2:
   version "3.10.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-3.10.2.tgz#609ec2b0369da7cf2e6d9edff5da153cc31d87bd"


### PR DESCRIPTION
We can now collapse the Sidebar through a repsonsive button.
Props passed to change the canvas size to 100% width, the zoom buttons etc., dynamically, when the sidebar is collapsed. In this way, we gain 300px of extra space for our tree.

<img width="547" alt="Screenshot 2022-03-29 at 11 53 19" src="https://user-images.githubusercontent.com/58588711/160585450-f1530ec9-5bb4-46bc-8037-ce40b214faf1.png">

<img width="432" alt="Screenshot 2022-03-29 at 11 53 29" src="https://user-images.githubusercontent.com/58588711/160585454-2e113d48-60e8-4177-9359-385b7e168007.png">
