### PR TITLE
Evgenios/feature/proportional size on demand

### DIFF
--- a/packages/bratus-app/src/App.js
+++ b/packages/bratus-app/src/App.js
@@ -1,23 +1,20 @@
 import 'antd/dist/antd.css';
-
 import { i18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
 import { Alert, Spin } from 'antd';
-import React, { useEffect, useState } from 'react';
-
+import React, { useContext, useEffect, useState } from 'react';
 import { getParsedData } from './api';
 import ComponentTree from './components/ComponentTree/ComponentTree';
 import DefaultLayout from './components/DefaultLayoutPage/DefaultLayout';
 import useLocale from './hooks/useLocale';
-import ComponentBackgroundProvider from './providers/ComponentBackgroundProvider';
 import HighlightedComponentsProvider from './providers/HighlightedComponentsProvider';
 import I18nWatchLocaleProvider from './providers/I18nWatchLocaleProvider';
 import ThemeProvider from './providers/ThemeProvider';
 import { activate } from './utils/functions';
-
 import { getEdges, getNodes } from './utils/functions/nodes-and-edges';
 import { getLayoutedGraphElements } from './utils/functions/graphUtils';
 import { GraphLabels } from './utils/tokens/constants';
+import ComponentBackgroundContext from './contexts/ComponentBackgroundContext';
 
 const App = () => {
   const { locale } = useLocale();
@@ -25,15 +22,12 @@ const App = () => {
   const [nodeDetail, setNodeDetail] = useState({ visible: false, node: null });
   const [info, setInfo] = useState(null);
   const [treeLayoutDirection, setTreeLayoutDirection] = useState(undefined);
+  const { componentBackground } = useContext(ComponentBackgroundContext);
 
   useEffect(() => {
     activate(locale);
     /**
      * @param data is a set of nodes and edges: {nodes: Array, edges: Array}
-     * @param data.nodes returns an array of nodes which have the information below:
-     * {position: {x: 0, y: 0}, type: "reactComponent", id: "App", data: Object}
-     * @param data.edges returns an array of edges which have the information below:
-     * {id: "App:FilteredProducts:Header", source: "App:FilteredProducts", target: "App:FilteredProducts:Header", animated: false}
      */
     getParsedData()
       .then((data) => {
@@ -46,7 +40,8 @@ const App = () => {
           getLayoutedGraphElements(
             tree.concat(nodes, edges),
             GraphLabels.topToBottom,
-            setTreeLayoutDirection
+            setTreeLayoutDirection,
+            componentBackground
           )
         );
       })
@@ -58,29 +53,27 @@ const App = () => {
       <I18nWatchLocaleProvider>
         <ThemeProvider>
           <HighlightedComponentsProvider>
-            <ComponentBackgroundProvider>
-              <DefaultLayout
-                info={info}
-                nodeDetail={nodeDetail}
-                setNodeDetail={setNodeDetail}
-              >
-                {nodesAndEdges ? (
-                  <ComponentTree
-                    treeLayoutDirection={treeLayoutDirection}
-                    nodesAndEdges={nodesAndEdges}
-                    setTreeLayoutDirection={setTreeLayoutDirection}
+            <DefaultLayout
+              info={info}
+              nodeDetail={nodeDetail}
+              setNodeDetail={setNodeDetail}
+            >
+              {nodesAndEdges ? (
+                <ComponentTree
+                  treeLayoutDirection={treeLayoutDirection}
+                  nodesAndEdges={nodesAndEdges}
+                  setTreeLayoutDirection={setTreeLayoutDirection}
+                />
+              ) : (
+                <Spin spinning={true}>
+                  <Alert
+                    message="Nothing to show"
+                    description="Could not find any components to display"
+                    type="warning"
                   />
-                ) : (
-                  <Spin spinning={true}>
-                    <Alert
-                      message="Nothing to show"
-                      description="Could not find any components to display"
-                      type="warning"
-                    />
-                  </Spin>
-                )}
-              </DefaultLayout>
-            </ComponentBackgroundProvider>
+                </Spin>
+              )}
+            </DefaultLayout>
           </HighlightedComponentsProvider>
         </ThemeProvider>
       </I18nWatchLocaleProvider>

--- a/packages/bratus-app/src/components/ComponentDetails/ComponentDetails.jsx
+++ b/packages/bratus-app/src/components/ComponentDetails/ComponentDetails.jsx
@@ -10,7 +10,6 @@ import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { ComponentDetailsRow } from './ComponentDetails.sc';
 
 const ComponentDetails = ({ nodeDetail }) => {
-  console.log(nodeDetail);
   if (!nodeDetail.visible) {
     return <LoadingOutlined spin />;
   }

--- a/packages/bratus-app/src/components/ComponentNode/ComponentNode.jsx
+++ b/packages/bratus-app/src/components/ComponentNode/ComponentNode.jsx
@@ -1,57 +1,47 @@
-import { Row } from 'antd';
 import ColorHash from 'color-hash';
 import React, { useContext } from 'react';
-import { Handle, useStoreActions, useStoreState } from 'react-flow-renderer';
-
+import { Handle } from 'react-flow-renderer';
 import ComponentBackgroundContext from '../../contexts/ComponentBackgroundContext';
 import HighlightedComponentsContext from '../../contexts/HighlightedComponentsContext';
 import { rgbaToHex } from '../../utils/functions/rgbaToHex';
 import { GraphDirectionContext } from '../ComponentTree/ComponentTree';
-import {
-  EyeIcon,
-  LockIcon,
-  NodeButtonsRow,
-  StyledNode,
-  StyledNodeContent,
-  StyledTitle,
-  UnlockIcon,
-} from './ComponentNode.sc';
+import { StyledNode, StyledNodeContent, StyledTitle } from './ComponentNode.sc';
 
 const ComponentNode = (node) => {
-  const { highlightedComponents, setHighlightedComponents } = useContext(
-    HighlightedComponentsContext
-  );
-  const nodes = useStoreState((store) => store.nodes);
+  const { highlightedComponents } = useContext(HighlightedComponentsContext);
+  // const nodes = useStoreState((store) => store.nodes);
+
   const { componentBackground } = useContext(ComponentBackgroundContext);
-  const setSelectedElements = useStoreActions(
-    (actions) => actions.setSelectedElements
-  );
+
+  // const setSelectedElements = useStoreActions(
+  //   (actions) => actions.setSelectedElements
+  // );
 
   const treeLayoutDirection = useContext(GraphDirectionContext);
 
-  const lockComponent = () => {
-    const index = highlightedComponents.findIndex(
-      (component) => component.id === node.id
-    );
+  // const lockComponent = () => {
+  //   const index = highlightedComponents.findIndex(
+  //     (component) => component.id === node.id
+  //   );
 
-    const array = [...highlightedComponents];
-    if (index !== -1 && highlightedComponents[index].locked) {
-      array.splice(index, 1);
-      setHighlightedComponents(array);
-    } else if (index !== -1) {
-      array.splice(index, 1);
-      setHighlightedComponents([
-        ...array,
-        {
-          id: node.id,
-          componentName: node.data.label,
-          locked: true,
-          search: false,
-        },
-      ]);
-      setSelectedElements(nodes.filter((_node) => _node.id.includes(node.id)));
-    }
-  };
+  //   const array = [...highlightedComponents];
+  //   if (index !== -1 && highlightedComponents[index].locked) {
+  //     array.splice(index, 1);
+  //     setHighlightedComponents(array);
+  //   } else if (index !== -1) {
+  //     array.splice(index, 1);
+  //     setHighlightedComponents([
+  //       ...array,
+  //       {
+  //         id: node.id,
+  //         componentName: node.data.label,
+  //         locked: true,
+  //         search: false,
+  //       },
+  //     ]);
+  //     setSelectedElements(nodes.filter((_node) => _node.id.includes(node.id)));
+  //   }
+  // };
 
   const isHighlighted = () => {
     return highlightedComponents.some((component) =>
@@ -61,22 +51,18 @@ const ComponentNode = (node) => {
     );
   };
 
-  const isLocked = () => {
-    return highlightedComponents.some(
-      (component) =>
-        component.locked &&
-        node.id.match(
-          `${component.componentName}:+.+|${component.componentName}$`
-        )
-    );
-  };
+  // const isLocked = () => {
+  //   return highlightedComponents.some(
+  //     (component) =>
+  //       component.locked &&
+  //       node.id.match(
+  //         `${component.componentName}:+.+|${component.componentName}$`
+  //       )
+  //   );
+  // };
 
   const getBgColor = () => {
-    if (isLocked()) {
-      return 'red';
-    } else if (componentBackground.mode === 'white') {
-      return '#FFFFFFFF';
-    } else if (componentBackground.mode === 'label_hash') {
+    if (componentBackground.mode === 'proportional_size') {
       const hex = new ColorHash({
         lightness: 0.8,
         hue: { min: 0, max: 366 },
@@ -115,30 +101,21 @@ const ComponentNode = (node) => {
   return (
     <StyledNode
       linesOfCode={node.data.linesOfCode}
+      componentBackground={componentBackground}
+      treeLayoutDirection={treeLayoutDirection}
       isHighlighted={isHighlighted()}
-      isLocked={isLocked()}
       bgColor={getBgColor}
       fontColor={getFontColor()}
+      onDoubleClick={() => node.data.onShowNodeDetail(node)}
     >
       {node.data.inDegree > 0 && (
         <Handle type="target" position={layoutTargetHandlePosition} />
       )}
 
       <StyledNodeContent>
-        <Row>
-          <StyledTitle color={getFontColor} level={5}>
-            {node.data.label}
-          </StyledTitle>
-        </Row>
-
-        <NodeButtonsRow>
-          {isLocked() ? (
-            <LockIcon onClick={lockComponent} />
-          ) : (
-            <UnlockIcon onClick={lockComponent} />
-          )}
-          <EyeIcon onClick={() => node.data.onShowNodeDetail(node)} />
-        </NodeButtonsRow>
+        <StyledTitle color={getFontColor} level={5}>
+          {node.data.label}
+        </StyledTitle>
       </StyledNodeContent>
 
       {node.data.outDegree > 0 && (

--- a/packages/bratus-app/src/components/ComponentNode/ComponentNode.sc.js
+++ b/packages/bratus-app/src/components/ComponentNode/ComponentNode.sc.js
@@ -4,21 +4,30 @@ import Text from 'antd/lib/typography/Text';
 import Title from 'antd/lib/typography/Title';
 import styled, { css } from 'styled-components';
 
-import {
-  baseNodeHeight,
-  baseUnit,
-  // borderRadius,
-  nodeWidth,
-} from '../../utils/tokens/units';
+import { baseNodeHeight, baseUnit, nodeWidth } from '../../utils/tokens/units';
+const horizontalViewNodeHeight = baseNodeHeight / 2.3;
 
 export const StyledNode = styled.div`
-  /* height: ${({ linesOfCode }) => baseNodeHeight + linesOfCode}px; */
-  height: 100px;
-  width: ${nodeWidth}px;
+  height: ${({ linesOfCode, componentBackground, treeLayoutDirection }) => {
+    if (componentBackground.mode === 'proportional_size') {
+      if (treeLayoutDirection === 'TB') {
+        return `${horizontalViewNodeHeight + linesOfCode}px`;
+      }
+    }
+    return '75px';
+  }};
+  width: ${({ linesOfCode, componentBackground, treeLayoutDirection }) => {
+    if (componentBackground.mode === 'proportional_size') {
+      if (treeLayoutDirection === 'LR') {
+        return `${nodeWidth + linesOfCode}px`;
+      }
+    }
+    return `${nodeWidth}px`;
+  }};
   padding: ${baseUnit}px;
   border-radius: 100px;
-  border: ${({ isHighlighted, isLocked }) => {
-    return isHighlighted || isLocked ? '3px solid black' : '1px solid black';
+  border: ${({ isHighlighted }) => {
+    return isHighlighted ? '1.5px solid black' : '1px solid black';
   }};
   background-color: ${({ bgColor }) => bgColor};
   color: ${({ fontColor }) => fontColor};
@@ -38,6 +47,7 @@ export const StyledNodeContent = styled(Col)`
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
 `;
 
 export const NodeContentRow = styled(Row)`

--- a/packages/bratus-app/src/components/ComponentTree/private/LayoutButtons.jsx
+++ b/packages/bratus-app/src/components/ComponentTree/private/LayoutButtons.jsx
@@ -2,7 +2,7 @@ import {
   faGripHorizontal,
   faGripVertical,
 } from '@fortawesome/free-solid-svg-icons';
-import React, { useCallback } from 'react';
+import React, { useCallback, useContext } from 'react';
 import PropTypes from 'prop-types';
 import {
   LayoutButton,
@@ -11,6 +11,7 @@ import {
 } from '../ComponentTree.sc';
 import { getLayoutedGraphElements } from '../../../utils/functions/graphUtils';
 import { useZoomPanHelper } from 'react-flow-renderer';
+import ComponentBackgroundContext from '../../../contexts/ComponentBackgroundContext';
 
 export const LayoutButtons = ({
   layoutedNodesAndEdges,
@@ -19,12 +20,15 @@ export const LayoutButtons = ({
 }) => {
   const reactFlowInstance = useZoomPanHelper();
 
+  const { componentBackground } = useContext(ComponentBackgroundContext);
+
   const onChangeTreeLayout = useCallback(
     (treeLayoutDirection) => {
       const els = getLayoutedGraphElements(
         layoutedNodesAndEdges,
         treeLayoutDirection,
-        setTreeLayoutDirection
+        setTreeLayoutDirection,
+        componentBackground
       );
       setLayoutedNodesAndEdges(els);
     },
@@ -37,20 +41,21 @@ export const LayoutButtons = ({
         shape="round"
         type="primary"
         size="large"
-        onClick={() => {
-          onChangeTreeLayout('TB');
+        onClick={async () => {
+          await onChangeTreeLayout('TB');
           reactFlowInstance.fitView();
         }}
       >
         Horizontal Layout
         <StyledFontAwesomeIcon icon={faGripHorizontal} />
       </LayoutButton>
+
       <LayoutButton
         shape="round"
         type="primary"
         size="large"
-        onClick={() => {
-          onChangeTreeLayout('LR');
+        onClick={async () => {
+          await onChangeTreeLayout('LR');
           reactFlowInstance.fitView();
         }}
       >

--- a/packages/bratus-app/src/components/NavigationPanel/NavigationPanel.jsx
+++ b/packages/bratus-app/src/components/NavigationPanel/NavigationPanel.jsx
@@ -132,8 +132,8 @@ const NavigationPanel = ({ collapsed, setIsHelpVisible }) => {
                   ? 'proportional_size'
                   : componentBackground.mode
               }
-              onChange={async (value) =>
-                await setComponentBackground({
+              onChange={(value) =>
+                setComponentBackground({
                   ...componentBackground,
                   mode: value,
                 })

--- a/packages/bratus-app/src/components/NavigationPanel/NavigationPanel.jsx
+++ b/packages/bratus-app/src/components/NavigationPanel/NavigationPanel.jsx
@@ -73,9 +73,11 @@ const NavigationPanel = ({ collapsed, setIsHelpVisible }) => {
     idSplit.pop();
     return idSplit.join(':');
   };
+
   const isLeaf = (node) => {
     return node.data.outDegree == 0;
   };
+
   const generateTreeNodes = () => {
     if (nodes.length > 0) {
       setSearchOptions(
@@ -126,20 +128,25 @@ const NavigationPanel = ({ collapsed, setIsHelpVisible }) => {
 
             <DropdownInput
               defaultValue={
-                !componentBackground.mode ? 'white' : componentBackground.mode
+                !componentBackground.mode
+                  ? 'proportional_size'
+                  : componentBackground.mode
               }
-              onChange={(value) =>
-                setComponentBackground({ ...componentBackground, mode: value })
+              onChange={async (value) =>
+                await setComponentBackground({
+                  ...componentBackground,
+                  mode: value,
+                })
               }
             >
               <Select.Option value="white">White</Select.Option>
 
-              <Select.Option value="label_hash">
-                Based on Label Hash
+              <Select.Option value="proportional_size">
+                Proportional Size based on Lines
               </Select.Option>
 
               <Select.Option value="loc_reference">
-                Based on Lines of Code
+                Colorization based on Lines
               </Select.Option>
             </DropdownInput>
 

--- a/packages/bratus-app/src/index.js
+++ b/packages/bratus-app/src/index.js
@@ -1,12 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-
 import App from './App';
+import ComponentBackgroundProvider from './providers/ComponentBackgroundProvider';
 import reportWebVitals from './reportWebVitals';
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <ComponentBackgroundProvider>
+      <App />
+    </ComponentBackgroundProvider>
   </React.StrictMode>,
   document.getElementById('root')
 );

--- a/packages/bratus-app/src/providers/ComponentBackgroundProvider.js
+++ b/packages/bratus-app/src/providers/ComponentBackgroundProvider.js
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import ComponentBackgroundContext from '../contexts/ComponentBackgroundContext';
 import useStickyState from '../hooks/useStickyState';
 

--- a/packages/bratus-app/src/utils/functions/graphUtils.js
+++ b/packages/bratus-app/src/utils/functions/graphUtils.js
@@ -21,7 +21,8 @@ dagreGraph.setDefaultEdgeLabel(() => ({}));
 export const getLayoutedGraphElements = (
   nodesAndEdges,
   treeLayoutDirection = 'TB',
-  setTreeLayoutDirection = () => {}
+  setTreeLayoutDirection = () => {},
+  componentBackground
 ) => {
   dagreGraph.setGraph({ rankdir: treeLayoutDirection });
 
@@ -30,15 +31,30 @@ export const getLayoutedGraphElements = (
   nodesAndEdges.forEach((graphElement) => {
     if (isNode(graphElement)) {
       if (treeLayoutDirection === GraphLabels.topToBottom) {
-        dagreGraph.setNode(graphElement.id, {
-          width: nodeWidth,
-          height: baseNodeHeight * aditionalSpaceMultiplier,
-        });
+        if (componentBackground.mode === 'proportional_size') {
+          dagreGraph.setNode(graphElement.id, {
+            width: nodeWidth,
+            height:
+              baseNodeHeight * aditionalSpaceMultiplier +
+              graphElement.data.linesOfCode,
+          });
+        } else {
+          dagreGraph.setNode(graphElement.id, {
+            width: nodeWidth,
+            height: baseNodeHeight * 2.5,
+          });
+        }
       }
 
       if (treeLayoutDirection == GraphLabels.leftToRight) {
+        if (componentBackground.mode === 'proportional_size') {
+          dagreGraph.setNode(graphElement.id, {
+            width: nodeWidth * aditionalSpaceMultiplier,
+            height: baseNodeHeight + graphElement.data.linesOfCode,
+          });
+        }
         dagreGraph.setNode(graphElement.id, {
-          width: nodeWidth * aditionalSpaceMultiplier,
+          width: nodeWidth * 2.5,
           height: baseNodeHeight,
         });
       }
@@ -60,13 +76,38 @@ export const getLayoutedGraphElements = (
       graphElement.targetPosition = isHorizontalLayout ? 'left' : 'top';
       graphElement.sourcePosition = isHorizontalLayout ? 'right' : 'bottom';
 
-      graphElement.position = {
-        x:
-          nodeWithPosition.x -
-          (nodeWidth * aditionalSpaceMultiplier) / 2 +
-          Math.random() / 1000,
-        y: nodeWithPosition.y - 36 / 2,
-      };
+      if (treeLayoutDirection === 'TB') {
+        if (componentBackground.mode === 'proportional_size') {
+          graphElement.position = {
+            x: nodeWithPosition.x - nodeWidth + Math.random() / 1000,
+            y: nodeWithPosition.y - (36 + graphElement.data.linesOfCode) / 3,
+          };
+        } else {
+          graphElement.position = {
+            x: nodeWithPosition.x - nodeWidth,
+            y: nodeWithPosition.y - baseNodeHeight,
+          };
+        }
+      }
+
+      if (treeLayoutDirection === 'LR') {
+        if (componentBackground.mode === 'proportional_size') {
+          graphElement.position = {
+            x:
+              nodeWithPosition.x -
+              (nodeWidth + graphElement.data.linesOfCode) / 3,
+            y: nodeWithPosition.y - baseNodeHeight + Math.random() / 1000,
+          };
+        } else {
+          graphElement.position = {
+            x:
+              nodeWithPosition.x -
+              (nodeWidth * aditionalSpaceMultiplier) / 2 +
+              Math.random() / 1000,
+            y: nodeWithPosition.y,
+          };
+        }
+      }
     }
 
     return graphElement;


### PR DESCRIPTION
We discussed about the benefits of offering different visualisations on demand.
Some developers might want to see how big a component is by colour, while others by size.

The label_hash is now proportional_size and it offers scaling based on size while keeping the label_hash colour, to make it easy to spot same components that are used many times. In the proportional size mode, when the tree layout is vertical, component nodes scale based on lines of code horizontally, and when it's horizontal, they scale vertically. 

Then there are the "white" and the "colorisation based on lines of code" versions that use a static component size.

Also fixed a bug, implemented async functionality on the "Change Layout" buttons, to fit the tree instance in the screen on click and implemented open component details on double click.


<img width="1080" alt="Screenshot 2022-04-04 at 12 28 53" src="https://user-images.githubusercontent.com/58588711/161526641-9a17ebbc-64a6-42b7-999e-006af29ae899.png">
<img width="1108" alt="Screenshot 2022-04-04 at 12 29 27" src="https://user-images.githubusercontent.com/58588711/161526646-bf956d3b-1b0e-495a-9205-1448eaad7322.png">
<img width="1108" alt="Screenshot 2022-04-04 at 12 35 35" src="https://user-images.githubusercontent.com/58588711/161526840-69b594da-d550-458f-93cc-69e2d2973b0f.png">
