### PR TITLE
Piotrek/bugfix/conditional-rendering

### DIFF
--- a/packages/bratus-app/src/utils/functions/nodes-and-edges.js
+++ b/packages/bratus-app/src/utils/functions/nodes-and-edges.js
@@ -26,7 +26,9 @@ export const getEdges = (data) => {
       labelStyle: {
         fill: '#fff',
       },
-      style: { stroke: edge.label ? 'red' : '#000' },
+      style: {
+        stroke: edge.conditional ? 'green' : edge.label ? 'red' : '#000',
+      },
     };
   });
 

--- a/packages/bratus-cli/src/parser/ASTParser.ts
+++ b/packages/bratus-cli/src/parser/ASTParser.ts
@@ -117,6 +117,9 @@ class ASTParser {
         const elements: JSXElement[] = [new JSXElement(path)];
         const attributes: Attribute[] = [new Attribute()];
         let ifStatementLevel = 0;
+
+        // Beginning of the traverse function:
+
         traverse(ast, {
           ImportDeclaration({ node }) {
             const modulePath = node.source.value;
@@ -174,6 +177,18 @@ class ASTParser {
           IfStatement() {
             ASTParser.logEntry(
               `[Info] Increment level of depth in if statement: ${ifStatementLevel}`
+            );
+            ifStatementLevel++;
+          },
+          LogicalExpression() {
+            ASTParser.logEntry(
+              `[Info] Conditional rendering by '&&' found for this componenet.`
+            );
+            ifStatementLevel++;
+          },
+          ConditionalExpression() {
+            ASTParser.logEntry(
+              `[Info] Conditional rendering by a ternary operator found for this componenet.`
             );
             ifStatementLevel++;
           },
@@ -298,7 +313,11 @@ class ASTParser {
               if (attributes.length === 0) attributes.push(new Attribute());
             }
 
-            if (node.type == 'IfStatement') {
+            if (
+              node.type == 'IfStatement' ||
+              node.type == 'LogicalExpression' ||
+              node.type == 'ConditionalExpression'
+            ) {
               ASTParser.logEntry(
                 `[Info] Reduce level of depth in if statement: ${ifStatementLevel}`
               );

--- a/packages/bratus-cli/src/parser/Builder/JSXElement.ts
+++ b/packages/bratus-cli/src/parser/Builder/JSXElement.ts
@@ -3,7 +3,9 @@ import ParsableElement from './ParsableElement';
 
 class JSXElement extends ParsableElement {
   private attributes: Map<string, Attribute> = new Map<string, Attribute>();
-  private optional = false;
+  // private optional = false;
+  private conditional = false;
+  public conditionalOperator: string | undefined;
   public routePath: string | undefined;
   public isRouteElement = false;
   constructor(path: string) {
@@ -20,16 +22,24 @@ class JSXElement extends ParsableElement {
     }
   }
 
-  setOptional(isOptional: boolean): void {
-    if (this.isRouteElement) {
-      this.optional = true;
-    } else {
-      this.optional = isOptional;
-    }
+  // setOptional(isOptional: boolean): void {
+  //   if (this.isRouteElement) {
+  //     this.optional = true;
+  //   } else {
+  //     this.optional = isOptional;
+  //   }
+  // }
+
+  setConditional(): void {
+    this.conditional = true;
   }
 
-  isOptional(): boolean {
-    return this.optional;
+  // isOptional(): boolean {
+  //   return this.optional;
+  // }
+
+  isConditional(): boolean {
+    return this.conditional;
   }
 
   getAttribute(key: string): Attribute | undefined {

--- a/packages/bratus-cli/src/parser/Graph/Edge.ts
+++ b/packages/bratus-cli/src/parser/Graph/Edge.ts
@@ -4,6 +4,7 @@ class Edge {
   public target: string;
   public animated: boolean;
   public label: string | undefined;
+  public conditional: string | undefined;
 
   constructor(id: string, source: string, target: string, optional: boolean) {
     this.id = id;

--- a/packages/bratus-cli/src/parser/Graph/Graph.ts
+++ b/packages/bratus-cli/src/parser/Graph/Graph.ts
@@ -98,10 +98,14 @@ class Graph {
       target.id,
       source.id,
       target.id,
-      element.isOptional()
+      element.isConditional() || element.isRouteElement
     );
     if (element.isRouteElement && element.routePath) {
       edge.label = element.routePath;
+    }
+    if (element.isConditional()) {
+      edge.conditional = element.conditionalOperator;
+      edge.label = edge.conditional;
     }
     this.edges.push(edge);
     source.data.outDegree++;


### PR DESCRIPTION
Before:
Components rendered conditionally by && or ternary operators showed up as 'always' rendered with a solid black line.

`{render && <Page />}`
`{render ? <Footer /> : <div>I am a div</div>}`

<img width="676" alt="Screenshot 2022-04-04 at 14 45 17" src="https://user-images.githubusercontent.com/71826552/161547263-470c4e87-cf83-4856-a4eb-80e4c08e5b07.png">

I added some functionality to the parser, so now these components are shown as they should:

<img width="677" alt="Screenshot 2022-04-04 at 14 46 48" src="https://user-images.githubusercontent.com/71826552/161547620-0b4fda25-daf4-4a00-b19d-ac1ff97fb05d.png">


