### PR TITLE
Implementing prefered vertical layout option

### DIFF
--- a/packages/bratus-app/src/App.js
+++ b/packages/bratus-app/src/App.js
@@ -15,14 +15,27 @@ import { getEdges, getNodes } from './utils/functions/nodes-and-edges';
 import { getLayoutedGraphElements } from './utils/functions/graphUtils';
 import { GraphLabels } from './utils/tokens/constants';
 import ComponentBackgroundContext from './contexts/ComponentBackgroundContext';
+import useStickyState from './hooks/useStickyState';
 
 const App = () => {
   const { locale } = useLocale();
   const [nodesAndEdges, setNodesAndEdges] = useState(null);
   const [nodeDetail, setNodeDetail] = useState({ visible: false, node: null });
   const [info, setInfo] = useState(null);
-  const [treeLayoutDirection, setTreeLayoutDirection] = useState(undefined);
   const { componentBackground } = useContext(ComponentBackgroundContext);
+
+  const [treeLayoutDirection, setTreeLayoutDirection] = useState(undefined);
+
+  //  If the user prefers the vertical layout as favorite, he/she can click it as preferred
+  // in the help panel. The App.js getLayoutedGraphElement() will check the local storage,
+  //  otherwise it will set horizontal as the default.
+  const [verticalTreeLayoutAsDefault, setVerticalTreeLayoutAsDefault] =
+    useStickyState(false, 'bratus:prefer-vertical-layout');
+
+  const treeLayoutOnCompile =
+    verticalTreeLayoutAsDefault === true
+      ? GraphLabels.leftToRight
+      : GraphLabels.topToBottom;
 
   useEffect(() => {
     activate(locale);
@@ -39,7 +52,7 @@ const App = () => {
         setNodesAndEdges(
           getLayoutedGraphElements(
             tree.concat(nodes, edges),
-            GraphLabels.topToBottom,
+            treeLayoutOnCompile,
             setTreeLayoutDirection,
             componentBackground
           )
@@ -57,6 +70,8 @@ const App = () => {
               info={info}
               nodeDetail={nodeDetail}
               setNodeDetail={setNodeDetail}
+              verticalTreeLayoutAsDefault={verticalTreeLayoutAsDefault}
+              setVerticalTreeLayoutAsDefault={setVerticalTreeLayoutAsDefault}
             >
               {nodesAndEdges ? (
                 <ComponentTree

--- a/packages/bratus-app/src/components/DefaultLayoutPage/DefaultLayout.jsx
+++ b/packages/bratus-app/src/components/DefaultLayoutPage/DefaultLayout.jsx
@@ -12,7 +12,14 @@ import {
   NavigationTriggerButton,
 } from './DefaultLayout.sc';
 
-const DefaultLayout = ({ children, info, nodeDetail, setNodeDetail }) => {
+const DefaultLayout = ({
+  children,
+  info,
+  nodeDetail,
+  setNodeDetail,
+  verticalTreeLayoutAsDefault,
+  setVerticalTreeLayoutAsDefault,
+}) => {
   const [hideHelpOnStartUp, setHideHelpOnStartUp] = useStickyState(
     false,
     'react-bratus:hide-help'
@@ -65,6 +72,8 @@ const DefaultLayout = ({ children, info, nodeDetail, setNodeDetail }) => {
 
       <ReactFlowProvider>
         <HelpPanel
+          verticalTreeLayoutAsDefault={verticalTreeLayoutAsDefault}
+          setVerticalTreeLayoutAsDefault={setVerticalTreeLayoutAsDefault}
           isHelpVisible={isHelpVisible}
           setIsHelpVisible={setIsHelpVisible}
           hideHelpOnStartUp={hideHelpOnStartUp}
@@ -76,6 +85,8 @@ const DefaultLayout = ({ children, info, nodeDetail, setNodeDetail }) => {
 };
 
 DefaultLayout.propTypes = {
+  verticalTreeLayoutAsDefault: PropTypes.any,
+  setVerticalTreeLayoutAsDefault: PropTypes.any,
   info: PropTypes.any,
   nodeDetail: PropTypes.any,
   setNodeDetail: PropTypes.func,

--- a/packages/bratus-app/src/components/HelpPanel/HelpPanel.jsx
+++ b/packages/bratus-app/src/components/HelpPanel/HelpPanel.jsx
@@ -1,15 +1,15 @@
 import { Divider, Drawer, Typography } from 'antd';
 import Checkbox from 'antd/lib/checkbox/Checkbox';
 import PropTypes from 'prop-types';
-import React, { useContext, useState } from 'react';
-import ReactFlow from 'react-flow-renderer';
+import React, { useState } from 'react';
+// import ReactFlow from 'react-flow-renderer';
 
-import HighlightedComponentsContext from '../../contexts/HighlightedComponentsContext';
+// import HighlightedComponentsContext from '../../contexts/HighlightedComponentsContext';
 // import { getLayoutedElements } from '../../utils/functions/graphUtils';
 // import { GraphLabels } from '../../utils/tokens/constants';
-import ComponentNode from '../ComponentNode/ComponentNode';
+// import ComponentNode from '../ComponentNode/ComponentNode';
 // import { Elements } from './HelpPanel.mock-data';
-import { HelpPanelTreeWrapper } from './HelpPanel.sc';
+// import { HelpPanelTreeWrapper } from './HelpPanel.sc';
 const { Title, Paragraph, Link } = Typography;
 
 const HelpPanel = ({
@@ -17,39 +17,41 @@ const HelpPanel = ({
   hideHelpOnStartUp,
   setIsHelpVisible,
   setHideHelpOnStartUp,
+  verticalTreeLayoutAsDefault,
+  setVerticalTreeLayoutAsDefault,
 }) => {
-  const { highlightedComponents, setHighlightedComponents } = useContext(
-    HighlightedComponentsContext
-  );
+  // const { highlightedComponents, setHighlightedComponents } = useContext(
+  //   HighlightedComponentsContext
+  // );
   const [ellipsis] = useState(true);
-  const highlightComponent = (node) => {
-    const componentName = node ? node.data.label : null;
-    setHighlightedComponents([
-      ...highlightedComponents.filter((_node) => _node.locked),
-      {
-        id: node.id,
-        componentName: componentName,
-        locked: false,
-        search: false,
-      },
-    ]);
-  };
+  // const highlightComponent = (node) => {
+  //   const componentName = node ? node.data.label : null;
+  //   setHighlightedComponents([
+  //     ...highlightedComponents.filter((_node) => _node.locked),
+  //     {
+  //       id: node.id,
+  //       componentName: componentName,
+  //       locked: false,
+  //       search: false,
+  //     },
+  //   ]);
+  // };
 
-  const removeHighlight = (node) => {
-    const index = highlightedComponents.findIndex(
-      (component) => component.id === node.id
-    );
-    if (index !== -1) {
-      const highlightedComponent = highlightedComponents[index];
-      if (!highlightedComponent.locked) {
-        const array = [...highlightedComponents];
-        array.splice(index, 1);
-        setHighlightedComponents(array);
-      }
-    }
-  };
+  // const removeHighlight = (node) => {
+  //   const index = highlightedComponents.findIndex(
+  //     (component) => component.id === node.id
+  //   );
+  //   if (index !== -1) {
+  //     const highlightedComponent = highlightedComponents[index];
+  //     if (!highlightedComponent.locked) {
+  //       const array = [...highlightedComponents];
+  //       array.splice(index, 1);
+  //       setHighlightedComponents(array);
+  //     }
+  //   }
+  // };
 
-  const resetHighlight = () => setHighlightedComponents([]);
+  // const resetHighlight = () => setHighlightedComponents([]);
   return (
     <Drawer
       width={720}
@@ -64,7 +66,7 @@ const HelpPanel = ({
         what they represent.
       </Paragraph>
 
-      <HelpPanelTreeWrapper>
+      {/* <HelpPanelTreeWrapper>
         <ReactFlow
           // elements={getLayoutedElements(Elements, GraphLabels.leftToRight)}
           nodeTypes={{ reactComponent: ComponentNode }}
@@ -75,7 +77,7 @@ const HelpPanel = ({
           defaultPosition={[150, 0]}
           defaultZoom={0.5}
         />
-      </HelpPanelTreeWrapper>
+      </HelpPanelTreeWrapper> */}
 
       <Divider />
 
@@ -107,6 +109,14 @@ const HelpPanel = ({
 
       <Divider />
 
+      <Checkbox
+        checked={verticalTreeLayoutAsDefault}
+        onChange={(e) => setVerticalTreeLayoutAsDefault(e.target.checked)}
+      >
+        {'Set vertical layout as default'}
+      </Checkbox>
+
+      <Divider />
       <Title level={5}>Changelog</Title>
 
       <Paragraph
@@ -140,8 +150,6 @@ const HelpPanel = ({
         Removed Info section <br />
         <b>2.0.2</b> <br />- First release
       </Paragraph>
-
-      <Divider />
     </Drawer>
   );
 };
@@ -151,6 +159,8 @@ HelpPanel.propTypes = {
   hideHelpOnStartUp: PropTypes.bool,
   setIsHelpVisible: PropTypes.func,
   setHideHelpOnStartUp: PropTypes.func,
+  verticalTreeLayoutAsDefault: PropTypes.any,
+  setVerticalTreeLayoutAsDefault: PropTypes.any,
 };
 
 export default HelpPanel;


### PR DESCRIPTION
We discussed about giving the option to the user, to be able to set vertical as the default layout if he/ she wants to.

Now they can press a checkbox that saves a condition in the local storage, and the applcation always checks if the localstorage is empty or not on recompile, parse, refresh.

The text that is displayed, and the help panel will be reworked completely anyway, so we can change text, design etc., in another PR.

close #62 