### PR TITLE
[Feature] Fit the Tree on the screen when collapsing sidebar #63

### DIFF
--- a/packages/bratus-app/src/components/ComponentTree/private/LayoutButtons.jsx
+++ b/packages/bratus-app/src/components/ComponentTree/private/LayoutButtons.jsx
@@ -44,11 +44,11 @@ export const LayoutButtons = ({
         shape="round"
         type="primary"
         size="middle"
-        onClick={async () => {
-          await onChangeTreeLayout(GraphLabels.topToBottom);
+        onClick={() => {
+          onChangeTreeLayout(GraphLabels.topToBottom);
           setTimeout(() => {
-            reactFlowInstance.fitView();
-          }, 500);
+            reactFlowInstance.fitView({ duration: 500 });
+          }, 0);
         }}
       >
         {ButtonLabels.horizontal}
@@ -59,11 +59,11 @@ export const LayoutButtons = ({
         shape="round"
         type="primary"
         size="middle"
-        onClick={async () => {
-          await onChangeTreeLayout(GraphLabels.leftToRight);
+        onClick={() => {
+          onChangeTreeLayout(GraphLabels.leftToRight);
           setTimeout(() => {
-            reactFlowInstance.fitView();
-          }, 500);
+            reactFlowInstance.fitView({ duration: 500 });
+          }, 0);
         }}
       >
         {ButtonLabels.vertical}

--- a/packages/bratus-app/src/components/NavigationPanel/NavigationPanel.jsx
+++ b/packages/bratus-app/src/components/NavigationPanel/NavigationPanel.jsx
@@ -1,5 +1,5 @@
 import { Menu } from 'antd';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { navigationWidth } from '../../utils/constants/units';
 import {
   AppTitle,
@@ -22,8 +22,19 @@ import {
   defaultOpenKeys,
   NavigationLabels,
 } from '../../utils/constants/constants';
+import { useZoomPanHelper } from 'react-flow-renderer';
 
 const NavigationPanel = ({ isNavCollapsed, setIsHelpVisible }) => {
+  const reactFlowInstance = useZoomPanHelper();
+
+  useEffect(() => {
+    console.log('useEffect()');
+    setTimeout(() => {
+      reactFlowInstance.fitView();
+      console.log('fitView()');
+    }, 200);
+  }, [isNavCollapsed, reactFlowInstance.fitView()]);
+
   return (
     <>
       <NavigationSider

--- a/packages/bratus-app/src/components/NavigationPanel/NavigationPanel.jsx
+++ b/packages/bratus-app/src/components/NavigationPanel/NavigationPanel.jsx
@@ -28,10 +28,8 @@ const NavigationPanel = ({ isNavCollapsed, setIsHelpVisible }) => {
   const reactFlowInstance = useZoomPanHelper();
 
   useEffect(() => {
-    console.log('useEffect()');
     setTimeout(() => {
       reactFlowInstance.fitView();
-      console.log('fitView()');
     }, 200);
   }, [isNavCollapsed, reactFlowInstance.fitView()]);
 

--- a/packages/bratus-app/src/components/NavigationPanel/NavigationPanel.jsx
+++ b/packages/bratus-app/src/components/NavigationPanel/NavigationPanel.jsx
@@ -29,9 +29,9 @@ const NavigationPanel = ({ isNavCollapsed, setIsHelpVisible }) => {
 
   useEffect(() => {
     setTimeout(() => {
-      reactFlowInstance.fitView();
-    }, 200);
-  }, [isNavCollapsed, reactFlowInstance.fitView()]);
+      reactFlowInstance.fitView({ duration: 700 });
+    }, 0);
+  }, [isNavCollapsed]);
 
   return (
     <>


### PR DESCRIPTION
I found a way to fit the tree after collapsing or opening the sidebar.
A simple useEffect in the NavigationPanel component.

```
const reactFlowInstance = useZoomPanHelper();

  useEffect(() => {
    setTimeout(() => {
      reactFlowInstance.fitView();
    }, 200);
  }, [isNavCollapsed, reactFlowInstance.fitView()]);
```

closes #63 